### PR TITLE
removed '-SNAPSHOT' after spark version 1.3.1.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ scalaVersion := "2.10.4"
 parallelExecution in Test := false
 
 {
-  val defaultSparkVersion = "1.3.1-SNAPSHOT"
+  val defaultSparkVersion = "1.3.1"
   val sparkVersion = scala.util.Properties.envOrElse("SPARK_VERSION", defaultSparkVersion)
   val excludeHadoop = ExclusionRule(organization = "org.apache.hadoop")
   libraryDependencies ++= Seq(


### PR DESCRIPTION
The SNAPSHOT description causes the following unresolved dependencies:
```
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.apache.spark#spark-core_2.10;1.3.1-SNAPSHOT: not found
[warn]  :: org.apache.spark#spark-mllib_2.10;1.3.1-SNAPSHOT: not found
```
The actual dependencies do not have the SNAPSHOT description. 